### PR TITLE
Make time more human readable

### DIFF
--- a/long-running.bash
+++ b/long-running.bash
@@ -36,6 +36,23 @@ function notify_when_long_running_commands_finish_install() {
         echo nowindowid
     }
 
+    function sec_to_human () {
+        local H=''
+        local M=''
+        local S=''
+
+        local h=$(($1 / 3600))
+        [ $h -gt 0 ] && H="${h} hour" && [ $h -gt 1 ] && H="${H}s"
+
+        local m=$((($1 / 60) % 60))
+        [ $m -gt 0 ] && M=" ${m} min" && [ $m -gt 1 ] && M="${M}s"
+
+        local s=$(($1 % 60))
+        [ $s -gt 0 ] && S=" ${s} sec" && [ $s -gt 1 ] && S="${S}s"
+
+        echo $H$M$S
+    }
+
     function precmd () {
 
         if [[ -n "$__udm_last_command_started" ]]; then
@@ -46,20 +63,21 @@ function notify_when_long_running_commands_finish_install() {
             if [[ $current_window != $__udm_last_window ]] ||
                 [[ $current_window == "nowindowid" ]] ; then
                 local time_taken=$(( $now - $__udm_last_command_started ))
+                local time_taken_human=$(sec_to_human $time_taken)
                 if [[ $time_taken -gt $LONG_RUNNING_COMMAND_TIMEOUT ]] &&
                     [[ -n $DISPLAY ]] ; then
                     notify-send \
                         -i utilities-terminal \
                         -u low \
                         "Long command completed" \
-                        "\"$__udm_last_command\" took $time_taken seconds"
+                        "\"$__udm_last_command\" took $time_taken_human"
                 fi
                 if [[ -n $LONG_RUNNING_COMMAND_CUSTOM_TIMEOUT ]] &&
                     [[ -n $LONG_RUNNING_COMMAND_CUSTOM ]] &&
                     [[ $time_taken -gt $LONG_RUNNING_COMMAND_CUSTOM_TIMEOUT ]] ; then
                     # put in brackets to make it quiet
                     ( $LONG_RUNNING_COMMAND_CUSTOM \
-                        "\"$__udm_last_command\" took $time_taken seconds" & )
+                        "\"$__udm_last_command\" took $time_taken_human" & )
                 fi
             fi
         fi


### PR DESCRIPTION
The following changes since commit f7df0af235da29defefef784cf25ed0a671b1166:

  Change env var names to avoid global naming conflicts (2013-02-11 11:36:13 +1100)

are available in the git repository at:

  https://github.com/mikey/undistract-me test

for you to fetch changes up to 9179f6fea508248f961d4844e4a291195e10306f:

  Make output time printing more human readable ie:   61 sec == 1 min 1 sec (2013-02-13 16:19:21 +1100)

---

Michael Neuling (1):
      Make output time printing more human readable     ie:       61 sec == 1 min 1 sec

 long-running.bash |   22 ++++++++++++++++++++--
 1 file changed, 20 insertions(+), 2 deletions(-)
