### PR TITLE
Ignoring certain applications

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ or log out then log in again.
 By default, a long-running command is any command that takes more than 10s to
 complete.  If this default is not right for you, set
 `LONG_RUNNING_COMMAND_TIMEOUT` to a different number of seconds and export it.
+It is possible to disable notifications for certain commands by adding them 
+space-separated to `LONG_RUNNING_IGNORE_LIST` variable.
 
 ## Licensing
 

--- a/long-running.bash
+++ b/long-running.bash
@@ -64,8 +64,10 @@ function notify_when_long_running_commands_finish_install() {
                 [[ $current_window == "nowindowid" ]] ; then
                 local time_taken=$(( $now - $__udm_last_command_started ))
                 local time_taken_human=$(sec_to_human $time_taken)
+                local appname=$(basename "${__udm_last_command%% *}")
                 if [[ $time_taken -gt $LONG_RUNNING_COMMAND_TIMEOUT ]] &&
-                    [[ -n $DISPLAY ]] ; then
+                    [[ -n $DISPLAY ]] &&
+                    [[ ! " $LONG_RUNNING_IGNORE_LIST " == *" $appname "* ]] ; then
                     local icon=dialog-information
                     local urgency=low
                     if [[ $__preexec_exit_status != 0 ]]; then


### PR DESCRIPTION
When running GUI applications from the terminal the notifications about them might be annoying. In this commit, the name of command being run is matched against `LONG_RUNNING_IGNORE_LIST` environment variable; on match, the notification is suppressed.

Example usage:

```
export LONG_RUNNING_IGNORE_LIST='xterm opera firefox xmgrace vmd'
```
