### PR TITLE
Add ignore list to custom command as well

### DIFF
--- a/long-running.bash
+++ b/long-running.bash
@@ -87,7 +87,8 @@ function notify_when_long_running_commands_finish_install() {
                 fi
                 if [[ -n $LONG_RUNNING_COMMAND_CUSTOM_TIMEOUT ]] &&
                     [[ -n $LONG_RUNNING_COMMAND_CUSTOM ]] &&
-                    [[ $time_taken -gt $LONG_RUNNING_COMMAND_CUSTOM_TIMEOUT ]] ; then
+                    [[ $time_taken -gt $LONG_RUNNING_COMMAND_CUSTOM_TIMEOUT ]] &&
+                    [[ ! " $LONG_RUNNING_IGNORE_LIST " == *" $appname "* ]] ; then
                     # put in brackets to make it quiet
                     export __preexec_exit_status
                     ( $LONG_RUNNING_COMMAND_CUSTOM \


### PR DESCRIPTION
In "8dc0c00 Adding ignore list" we added an ignore list env variable, but
didn't add it to the custom command section.

This adds it to the custom command sections so that these commands will be
ignored for a custom command as well.
