### PR TITLE
Make getting time work in older bash.

### DIFF
--- a/long-running.bash
+++ b/long-running.bash
@@ -27,6 +27,14 @@ fi
 
 function notify_when_long_running_commands_finish_install() {
 
+    function get_now() {
+        local secs
+        if ! secs=$(printf "%(%s)T" -1 2> /dev/null) ; then
+            secs=$(date +'%s')
+        fi
+        echo $secs
+    }
+
     function active_window_id () {
         if [[ -n $DISPLAY ]] ; then
             set - $(xprop -root _NET_ACTIVE_WINDOW)
@@ -58,7 +66,7 @@ function notify_when_long_running_commands_finish_install() {
         if [[ -n "$__udm_last_command_started" ]]; then
             local now current_window
 
-            printf -v now "%(%s)T" -1
+            now=$(get_now)
             current_window=$(active_window_id)
             if [[ $current_window != $__udm_last_window ]] ||
                 [[ $current_window == "nowindowid" ]] ; then
@@ -100,7 +108,7 @@ function notify_when_long_running_commands_finish_install() {
 
     function preexec () {
         # use __udm to avoid global name conflicts
-        __udm_last_command_started=$(printf "%(%s)T\n" -1)
+        __udm_last_command_started=$(get_now)
         __udm_last_command=$(echo "$1")
         __udm_last_window=$(active_window_id)
     }


### PR DESCRIPTION
Using printf to get the time is only avalible in fairly new bash (bash 4.1.2
doesn't seem to have it).  It gives the following error:
  % printf -v now "%(%s)T" -1
  -bash: printf: `(': invalid format character

When this is not avaliable, fall back to slower date command.
