### PR TITLE
Move the time taken to the notification summary

### DIFF
--- a/long-running.bash
+++ b/long-running.bash
@@ -91,8 +91,8 @@ function notify_when_long_running_commands_finish_install() {
                         $notify \
                         -i $icon \
                         -u $urgency \
-                        "Long command completed" \
-                        "\"$__udm_last_command\" took $time_taken_human"
+                        "Command completed in $time_taken_human" \
+                        "$__udm_last_command"
                     else
                         echo -ne "\a"
                     fi


### PR DESCRIPTION
This change has a couple benefits:

- Notify messages with a long body can get cut truncated by the user's
notification GUI. Some GUIs (such as GNOME) don't offer any way to see
the truncated message at so the information about how long the command took
is completely lost.

- The message body becomes just the command string which nullifies the need
for quoting the command string string

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jml/undistract-me/34)
<!-- Reviewable:end -->
