### PR TITLE
Add option to play notification sound. Set PLAY_SOUND=1 to use.

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+undistract-me (0.1.0ubuntu1) UNRELEASED; urgency=medium
+
+  * Added option to play sound along with notification.
+
+ -- Akshay Naik <akshay@infineos.nowhere>  Wed, 22 Mar 2017 23:41:40 +0530
+
 undistract-me (0.1.0) quantal; urgency=low
 
   * Initial release of undistract-me

--- a/debian/control
+++ b/debian/control
@@ -10,7 +10,7 @@ Package: undistract-me
 Architecture: all
 Section: misc
 Priority: extra
-Depends: ${shlibs:Depends}, ${misc:Depends}, libnotify-bin
+Depends: ${shlibs:Depends}, ${misc:Depends}, libnotify-bin, pulseaudio-utils, sound-theme-freedesktop
 Description: Notifies you when long-running terminal commands complete.
  .
  Uses notify-send to alert users whenever a shell command completes that took

--- a/long-running.bash
+++ b/long-running.bash
@@ -13,6 +13,9 @@ if [ -z "$LONG_RUNNING_COMMAND_TIMEOUT" ]; then
     LONG_RUNNING_COMMAND_TIMEOUT=10
 fi
 
+#Default is not to play sound along with notification.(0 is false, non-zero is true.)
+PLAY_SOUND=0
+
 # The pre-exec hook functionality is in a separate branch.
 if [ -z "$LONG_RUNNING_PREEXEC_LOCATION" ]; then
     LONG_RUNNING_PREEXEC_LOCATION=/usr/share/undistract-me/preexec.bash
@@ -95,6 +98,9 @@ function notify_when_long_running_commands_finish_install() {
                         "$__udm_last_command"
                     else
                         echo -ne "\a"
+                    fi
+                    if [ "$PLAY_SOUND" -ne 0 ]; then
+                    	paplay /usr/share/sounds/freedesktop/stereo/complete.oga
                     fi
                 fi
                 if [[ -n $LONG_RUNNING_COMMAND_CUSTOM_TIMEOUT ]] &&


### PR DESCRIPTION
Default behavior is left unchanged, i.e. notification sound is not played. 

Maybe undistract-me should have a separate config file(in user home directory) where customization stuff like LONG_RUNNING_COMMAND_TIMEOUT and PLAY_SOUND can be set.