### PR TITLE
Add option to play notification sound.

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,13 @@ complete.  If this default is not right for you, set
 It is possible to disable notifications for certain commands by adding them 
 space-separated to `LONG_RUNNING_IGNORE_LIST` variable.
 
+In addition to a visual notification you can make undistract-me notify you 
+by playing an audible sound along with the nitification popup by simply 
+setting the variable UDM_PLAY_SOUND to a non-zero integer on the command line.
+This functionality requires that pluseaudio and sound-theme-freedesktop 
+- which provides notification sound file - be installed on a Debian-based 
+system.
+
 ## Licensing
 
 All of undistract-me, including this file, is made available with the Expat

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+undistract-me (0.1.0ubuntu1) UNRELEASED; urgency=medium
+
+  * Added option to play sound along with notification.
+
+ -- Akshay Naik <akshay@infineos.nowhere>  Wed, 22 Mar 2017 23:41:40 +0530
+
 undistract-me (0.1.0) quantal; urgency=low
 
   * Initial release of undistract-me

--- a/debian/control
+++ b/debian/control
@@ -10,7 +10,7 @@ Package: undistract-me
 Architecture: all
 Section: misc
 Priority: extra
-Depends: ${shlibs:Depends}, ${misc:Depends}, libnotify-bin
+Depends: ${shlibs:Depends}, ${misc:Depends}, libnotify-bin, pulseaudio-utils, sound-theme-freedesktop
 Description: Notifies you when long-running terminal commands complete.
  .
  Uses notify-send to alert users whenever a shell command completes that took

--- a/long-running.bash
+++ b/long-running.bash
@@ -13,6 +13,11 @@ if [ -z "$LONG_RUNNING_COMMAND_TIMEOUT" ]; then
     LONG_RUNNING_COMMAND_TIMEOUT=10
 fi
 
+# Default is not to play sound along with notification. (0 is false, non-zero is true.)
+if [ -z "$UDM_PLAY_SOUND" ]; then
+	UDM_PLAY_SOUND=0
+fi
+
 # The pre-exec hook functionality is in a separate branch.
 if [ -z "$LONG_RUNNING_PREEXEC_LOCATION" ]; then
     LONG_RUNNING_PREEXEC_LOCATION=/usr/share/undistract-me/preexec.bash
@@ -93,6 +98,9 @@ function notify_when_long_running_commands_finish_install() {
                         -u $urgency \
                         "Command completed in $time_taken_human" \
                         "$__udm_last_command"
+                        if [[ "$UDM_PLAY_SOUND" != 0 ]]; then
+                            paplay /usr/share/sounds/freedesktop/stereo/complete.oga
+                        fi
                     else
                         echo -ne "\a"
                     fi


### PR DESCRIPTION
Default behavior is unchanged - does not play notification sound. To change this, set UDM_PLAY_SOUND in bashrc to non-zero value.