### PR TITLE
Bypass potential local date aliases.

### DIFF
--- a/long-running.bash
+++ b/long-running.bash
@@ -39,7 +39,7 @@ function notify_when_long_running_commands_finish_install() {
     function get_now() {
         local secs
         if ! secs=$(printf "%(%s)T" -1 2> /dev/null) ; then
-            secs=$(date +'%s')
+            secs=$(\date +'%s')
         fi
         echo $secs
     }


### PR DESCRIPTION
I have `date` aliased to something else (`date +%Y.%m.%d_%H%M`), and thus fails on this line since it's trying to do `date +%Y.%m.%d_%H%M +%s` which is not a valid command.

Escaping the command bypasses users' aliases.