### PR TITLE
Improve detection of window ID

### DIFF
--- a/long-running.bash
+++ b/long-running.bash
@@ -46,8 +46,7 @@ function notify_when_long_running_commands_finish_install() {
 
     function active_window_id () {
         if [[ -n $DISPLAY ]] ; then
-            set - $(xprop -root _NET_ACTIVE_WINDOW)
-            echo $5
+            xprop -root _NET_ACTIVE_WINDOW | awk '{print $5}'
             return
         fi
         echo nowindowid


### PR DESCRIPTION
I found window ID detection not working for me. Apparently all the output of xprop ends up in $1. I propose this fix.