### PR TITLE
Don’t run preexec_install on ZSH

### DIFF
--- a/long-running.bash
+++ b/long-running.bash
@@ -125,5 +125,8 @@ function notify_when_long_running_commands_finish_install() {
         __udm_last_window=$(active_window_id)
     }
 
-    preexec_install
+    if [ ! -n "$BASH" ];  then
+        # ZSH knows precmd and preexec, so this is unnecessary there (and broken too)
+        preexec_install
+    fi
 }

--- a/long-running.bash
+++ b/long-running.bash
@@ -125,8 +125,13 @@ function notify_when_long_running_commands_finish_install() {
         __udm_last_window=$(active_window_id)
     }
 
-    if [ ! -n "$BASH" ];  then
-        # ZSH knows precmd and preexec, so this is unnecessary there (and broken too)
+    if [[ ! -n "$ZSH_VERSION" ]]; then
+        # BASH needs some trap hackery to implement precmd and preexec
         preexec_install
+    else
+        # ZSH knows precmd and preexec, and the BASH traps in preexec_install are errors.
+	# So we need to instead call preexec_set_exit in precmd to have __preexec_exit_status set.
+	# The following line patches precmd, since doing an `if` in there would reset $?
+	eval "$(whence -f precmd | sed '2ipreexec_set_exit')"
     fi
 }


### PR DESCRIPTION
ZSH knows precmd and preexec, so preexec_install is unnecessary there

It’s also broken there, since the bash options set inside don’t exist for ZSH