### PR TITLE
Only execute preexec_install if defined

### DIFF
--- a/long-running.bash
+++ b/long-running.bash
@@ -125,5 +125,5 @@ function notify_when_long_running_commands_finish_install() {
         __udm_last_window=$(active_window_id)
     }
 
-    preexec_install
+    command -v "preexec_install" &> /dev/null && preexec_install
 }


### PR DESCRIPTION
Some external preexec scripts loaded with LONG_RUNNING_PREEXEC_LOCATION
do not use preexec_install, but instead install themselves automatically
when sourced (eg. https://github.com/rcaloras/bash-preexec/). This
commit avoids the error message "preexec_install not found" by skipping
the invocation of preexec_install if it is not defined. `command` is
defined by POSIX and should be available on all systems.

Tested:
  bash 5.0.3 on Linux with bash-preexec 0.3.8.0 Debian package and
  LONG_RUNNING_PREEXEC_LOCATION=/usr/share/bash-preexec/bash_preexec.sh