### PR TITLE
[Trivial] Fix preexec_set_exit from interfering with custom prompt commands

### DIFF
--- a/preexec.bash
+++ b/preexec.bash
@@ -89,6 +89,7 @@ function preexec_invoke_exec () {
 
 function preexec_set_exit () {
     __preexec_exit_status=$?
+    return $__preexec_exit_status
 }
 
 # Execute this to set up preexec and precmd execution.


### PR DESCRIPTION
It's common to have a custom PROMPT_COMMAND which reads the exit code. This stops undistract-me from interfering with the exit code produced by the program

example of a prompt command reading the exit code:

```bash
PROMPT_COMMAND=__prompt_command
__prompt_command() {
	local exit="$?"    # This needs to be first

	# set PS1 here
}

source /usr/share/undistract-me/long-running.bash
notify_when_long_running_commands_finish_install
```
