### PR TITLE
Fix incompatibilities with any other scripts that use `bash-preexec`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Important note
+## Important note
 
 This is a fork of [jml/undistract-me]. The original project uses `bash-preexec` incorrectly, making it incompatible with other scripts such as [bash-command-timer](https://github.com/qbouvet/undistract-me/archive/0.1.0.tar.gz), [bash-timer](https://github.com/hopeseekr/bash-timer). 
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## Important note
 
-This is a fork of [jml/undistract-me]. The original project uses `bash-preexec` incorrectly, making it incompatible with other scripts such as [bash-command-timer](https://github.com/qbouvet/undistract-me/archive/0.1.0.tar.gz), [bash-timer](https://github.com/hopeseekr/bash-timer). 
+This is a fork of [jml/undistract-me](https://github.com/jml/undistract-me). The original project uses `bash-preexec` incorrectly, making it incompatible with other scripts such as [bash-command-timer](https://github.com/qbouvet/undistract-me/archive/0.1.0.tar.gz), [bash-timer](https://github.com/hopeseekr/bash-timer). 
 
 I have a [pull-request](https://github.com/jml/undistract-me/issues/67) pending on the original project, but the authors seem to have abandonned the project. I made this fork because I need the feature. 
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,12 @@
+# Important note
+
+This is a fork of [jml/undistract-me]. The original project uses `bash-preexec` incorrectly, making it incompatible with other scripts such as [bash-command-timer](https://github.com/qbouvet/undistract-me/archive/0.1.0.tar.gz), [bash-timer](https://github.com/hopeseekr/bash-timer). 
+
+I have a [pull-request](https://github.com/jml/undistract-me/issues/67) pending on the original project, but the authors seem to have abandonned the project. I made this fork because I need the feature. 
+
+When/If the pull request is accepted, this fork will be deleted.
+
+
 # undistract-me
 
 Notifies you when long-running terminal commands complete.

--- a/long-running.bash
+++ b/long-running.bash
@@ -69,7 +69,7 @@ function notify_when_long_running_commands_finish_install() {
         echo $H$M$S
     }
 
-    function precmd () {
+    function __udm_precmd () {
 
         if [[ -n "$__udm_last_command_started" ]]; then
             local now current_window
@@ -118,12 +118,15 @@ function notify_when_long_running_commands_finish_install() {
         fi
     }
 
-    function preexec () {
+    function __udm_preexec () {
         # use __udm to avoid global name conflicts
         __udm_last_command_started=$(get_now)
         __udm_last_command=$(echo "$1")
         __udm_last_window=$(active_window_id)
     }
+
+    precmd_functions+=(__udm_precmd)
+    preexec_functions+=(__udm_preexec)
 
     preexec_install
 }

--- a/long-running.bash
+++ b/long-running.bash
@@ -123,7 +123,7 @@ function notify_when_long_running_commands_finish_install() {
                         "Command completed in $time_taken_human" \
                         "$__udm_last_command"
                         if [[ "$UDM_PLAY_SOUND" != 0 ]]; then
-                            paplay /usr/share/sounds/freedesktop/stereo/complete.oga
+                            paplay /usr/share/sounds/freedesktop/stereo/complete.oga &
                         fi
                     else
                         echo -ne "\a"

--- a/preexec.bash
+++ b/preexec.bash
@@ -1,5 +1,5 @@
-# Copyright (c) 2008-2012 undistract-me developers. See LICENSE for details.
-#
+#!/bin/bash
+
 # preexec.bash -- Bash support for ZSH-like 'preexec' and 'precmd' functions.
 
 # The 'preexec' function is executed before each interactive command is
@@ -30,14 +30,31 @@ then
     SCREEN_RUN_USER="$LC_SCREEN_RUN_USER"
 fi
 
-# Default do-nothing implementation of preexec.
-function preexec () {
-    true
+# This variable describes whether we are currently in "interactive mode";
+# i.e. whether this shell has just executed a prompt and is waiting for user
+# input.  It documents whether the current command invoked by the trace hook is
+# run interactively by the user; it's set immediately after the prompt hook,
+# and unset as soon as the trace hook is run.
+preexec_interactive_mode=""
+
+function bash_preexec () {
+    local savedqmark="$?";
+    _setqmark "${savedqmark}";
+    preexec;
+    for f in "${preexec_functions[@]}"; do
+        _setqmark "${savedqmark}";
+        "${f}" "$@";
+    done;
 }
 
-# Default do-nothing implementation of precmd.
-function precmd () {
-    true
+function bash_precmd () {
+    local savedqmark="$?";
+    _setqmark "${savedqmark}";
+    precmd;
+    for f in "${precmd_functions[@]}"; do
+        _setqmark "${savedqmark}";
+        "${f}" "$@";
+    done;
 }
 
 # This function is installed as the PROMPT_COMMAND; it is invoked before each
@@ -45,8 +62,15 @@ function precmd () {
 # was just displayed, to allow the DEBUG trap, below, to know that the next
 # command is likely interactive.
 function preexec_invoke_cmd () {
-    precmd
-    trap 'preexec_invoke_exec' DEBUG
+    local savedqmark="$?";
+    last_hist_ent="$(HISTTIMEFORMAT= history 1)";
+    _setqmark "${savedqmark}";
+    bash_precmd;
+    preexec_interactive_mode="yes";
+}
+
+function _setqmark () {
+    return "$1";
 }
 
 # This function is installed as the DEBUG trap.  It is invoked before each
@@ -54,16 +78,28 @@ function preexec_invoke_cmd () {
 # environment to attempt to detect if the current command is being invoked
 # interactively, and invoke 'preexec' if so.
 function preexec_invoke_exec () {
-    if [[ -n "$COMP_LINE" ]]
-    then
+    local savedqmark="$?";
+    if [[ -n "$COMP_LINE" ]]; then
         # We're in the middle of a completer.  This obviously can't be
         # an interactively issued command.
-        return
+        return;
     fi
-    trap '' DEBUG
-
-    if [[ "preexec_invoke_cmd" == "$BASH_COMMAND" ]]
-    then
+    if [[ -z "$preexec_interactive_mode" ]]; then
+        # We're doing something related to displaying the prompt.  Let the
+        # prompt set the title instead of me.
+        return;
+    else
+        # If we're in a subshell, then the prompt won't be re-displayed to put
+        # us back into interactive mode, so let's not set the variable back.
+        # In other words, if you have a subshell like
+        #   (sleep 1; sleep 2)
+        # You want to see the 'sleep 2' as a set_command_title as well.
+        if [[ 0 -eq "$BASH_SUBSHELL" ]]
+        then
+            preexec_interactive_mode="";
+        fi;
+    fi;
+    if [[ "preexec_invoke_cmd" == "$BASH_COMMAND" ]]; then
         # Sadly, there's no cleaner way to detect two prompts being displayed
         # one after another.  This makes it important that PROMPT_COMMAND
         # remain set _exactly_ as below in preexec_install.  Let's switch back
@@ -72,31 +108,51 @@ function preexec_invoke_exec () {
 
         # Given their buggy interaction between BASH_COMMAND and debug traps,
         # versions of bash prior to 3.1 can't detect this at all.
-        return
-    fi
+        preexec_interactive_mode="";
+        return;
+    fi;
 
     # In more recent versions of bash, this could be set via the "BASH_COMMAND"
     # variable, but using history here is better in some ways: for example, "ps
     # auxf | less" will show up with both sides of the pipe if we use history,
     # but only as "ps auxf" if not.
-    local this_command=`HISTTIMEFORMAT= history 1 | sed -e "s/^[ ]*[0-9]*[ ]*//g"`;
+    hist_ent="$(HISTTIMEFORMAT= history 1)";
+    local prev_hist_ent="${last_hist_ent}";
+    last_hist_ent="${hist_ent}";
+    if [[ "${prev_hist_ent}" != "${hist_ent}" ]]; then
+        local this_command="$(echo "${hist_ent}" | sed -e "s/^[ ]*[0-9]*[ ]*//g")";
+    else
+        local this_command="";
+    fi;
 
     # If none of the previous checks have earlied out of this function, then
     # the command is in fact interactive and we should invoke the user's
     # preexec hook with the running command as an argument.
-    preexec "$this_command"
-}
-
-function preexec_set_exit () {
-    __preexec_exit_status=$?
-    return $__preexec_exit_status
+    _setqmark "${savedqmark}";
+    bash_preexec "$this_command";
 }
 
 # Execute this to set up preexec and precmd execution.
 function preexec_install () {
 
+    # zsh has this functionality already, so don't do anything.
+    [[ $ZSH_VERSION ]] && return 0;
+
+    # Default do-nothing implementation of preexec.
+    function preexec () {
+        return "$?";
+    }
+
+    # Default do-nothing implementation of precmd.
+    function precmd () {
+        return "$?";
+    }
+
+    preexec_functions=();
+    precmd_functions=();
+
     # *BOTH* of these options need to be set for the DEBUG trap to be invoked
-    # in ( ) subshells.  This smells like a bug in bash to me.  The null stderr
+    # in ( ) subshells.  This smells like a bug in bash to me.  The null stackederr
     # redirections are to quiet errors on bash2.05 (i.e. OSX's default shell)
     # where the options can't be set, and it's impossible to inherit the trap
     # into subshells.
@@ -104,12 +160,11 @@ function preexec_install () {
     set -o functrace > /dev/null 2>&1
     shopt -s extdebug > /dev/null 2>&1
 
-    # Finally, install the actual traps.
-    if [ -n "$PROMPT_COMMAND" ]; then
-        PROMPT_COMMAND="preexec_set_exit;${PROMPT_COMMAND};preexec_invoke_cmd";
-    else
-        PROMPT_COMMAND="preexec_set_exit;preexec_invoke_cmd";
-    fi
+    # Finally, install the actual traps.  Note: this must be the _last_ command
+    # in PROMPT_COMMAND for it to work, otherwise the debug trap will get
+    # confused and execute for random other commands.
+    PROMPT_COMMAND="${PROMPT_COMMAND}"$'\n'"preexec_invoke_cmd;";
+    trap 'preexec_invoke_exec' DEBUG;
 }
 
 # Since this is the reason that 99% of everybody is going to bother with a
@@ -117,46 +172,126 @@ function preexec_install () {
 
 # Change the title of the xterm.
 function preexec_xterm_title () {
-    local title="$1"
-    echo -ne "\033]0;$title\007" > /dev/stderr
+    local title="$1";
+    echo -ne "\033]0;$title\007" 1>&2;
 }
 
 function preexec_screen_title () {
-    local title="$1"
-    echo -ne "\033k$1\033\\" > /dev/stderr
+    local title="$1";
+    echo -ne "\033k${title}\033\\" 1>&2;
 }
 
 # Abbreviate the "user@host" string as much as possible to preserve space in
 # screen titles.  Elide the host if the host is the same, elide the user if the
 # user is the same.
 function preexec_screen_user_at_host () {
-    local RESULT=""
     if [[ "$SCREEN_RUN_HOST" == "$SCREEN_HOST" ]]
     then
         return
     else
         if [[ "$SCREEN_RUN_USER" == "$USER" ]]
         then
-            echo -n "@${SCREEN_HOST}"
+            echo -n "@${SCREEN_HOST}";
         else
-            echo -n "${USER}@${SCREEN_HOST}"
+            echo -n "${USER}@${SCREEN_HOST}";
         fi
     fi
+}
+
+function timing_precmd () {
+    # elapsed-time/ran-command calculation follows
+    local rancmd="";
+    if [ -n "${thiscmd}" ]; then
+        local rancmd=" (${PROMPTCHAR} ${thiscmd})";
+        local when="${cmdstart}";
+    else
+        local when="${prevstart}";
+        local rancmd="";
+    fi;
+    local showelapsed="";
+    if [ -n "${when}" ]; then
+        local now="$(date +%s)";
+        local elapsed="$(($now-$when))";
+        if [[ "${elapsed}" != 0 ]]; then
+            local showelapsed=" (${elapsed} seconds elapsed)";
+            if type terminal-notifier > /dev/null 2>&1 ; then
+                # NB: PROMPT_LAST_ERROR is a feature of settings.bash, which
+                # means this is a layering violation.
+                if [[ "${elapsed}" -gt 1 ]]; then
+                    # https://stackoverflow.com/a/34503049/13564
+                    local sendactivator="$(case "${TERM_PROGRAM}" in
+    (Apple_Terminal)
+        echo -n com.apple.terminal;
+        ;;
+    (iTerm.app)
+        echo -n com.googlecode.iterm2;
+        ;;
+    (*)
+        echo -n com.apple.Mail;
+        ;;
+    esac;
+)";
+                    terminal-notifier \
+                        -title "Command '${thiscmd}'" \
+                        -subtitle "ran for ${elapsed} seconds" \
+                        -message "$(
+if [[ "${PROMPT_LAST_ERROR}" == "0" ]]; then
+    echo "and completed successfully.";
+else
+    echo "then exited with status ${PROMPT_LAST_ERROR}";
+fi;
+)" \
+                        -activate "${sendactivator}";
+                fi;
+            fi;
+        fi;
+    fi;
+    local done_symbol="â†ª";
+    if [[ "$TERM" == "cygwin" ]]; then
+        done_symbol="->";
+    fi;
+    echo -e "\033[38;5;88m ${done_symbol} $(date)${rancmd}${showelapsed}\033[0m" 1>&2;
+}
+
+function timing_preexec () {
+    # xterm seems to treat backslashes funny; they terminate the escape
+    # sequence or something.  I'm not sure why, but if we don't escape them
+    # by doubling them (like so) then running an interactive command with a
+    # backslash in it will result in a messed-up terminal and half a
+    # terminal title echoed onto the command line.
+    thiscmd="$(echo "$1" | sed -e 's/\\/\\\\/g' | head -n 1)"
+    if [ -z "$1" ]; then
+        prevstart="${cmdstart}";
+        cmdstart="$(date '+%s')";
+        return;
+    fi;
+    local start_symbol="â†©";
+    if [[ "$TERM" == "cygwin" ]]; then
+        start_symbol="<-";
+    fi;
+    echo -e "\033[38;5;23m ${start_symbol} $(date)\033[0m" 1>&2;
+    prevstart="${cmdstart}";
+    cmdstart="$(date '+%s')";
 }
 
 function preexec_xterm_title_install () {
     # These functions are defined here because they only make sense with the
     # preexec_install below.
-    function precmd () {
-        preexec_xterm_title "${TERM} - ${USER}@${SCREEN_HOST} `dirs -0` $PROMPTCHAR"
-        if [[ "${TERM}" == screen ]]
-        then
-            preexec_screen_title "`preexec_screen_user_at_host`${PROMPTCHAR}"
-        fi
+    preexec_install;
+
+    function xterm_title_precmd () {
+        if [[ "${TERM}" == screen ]]; then
+            preexec_screen_title "$(preexec_screen_user_at_host)${PROMPTCHAR}";
+        fi;
+        preexec_xterm_title \
+            "${PROMPTCHAR} - ${USER}@${SCREEN_HOST} $(dirs -0)";
+        timing_precmd "$@";
     }
 
-    function preexec () {
-        preexec_xterm_title "${TERM} - $1 {`dirs -0`} (${USER}@${SCREEN_HOST})"
+    function xterm_title_preexec () {
+        timing_preexec "$@";
+        preexec_xterm_title \
+            "${TERM} - $thiscmd {`dirs -0`} (${USER}@${SCREEN_HOST})";
         if [[ "${TERM}" == screen ]]
         then
             local cutit="$1"
@@ -173,9 +308,15 @@ function preexec_xterm_title_install () {
             else
                 local cmdtitle=":$cmdtitle"
             fi
-            preexec_screen_title "`preexec_screen_user_at_host`${PROMPTCHAR}$cmdtitle"
+            preexec_screen_title "$(preexec_screen_user_at_host)${PROMPTCHAR}$cmdtitle";
         fi
     }
+    precmd_functions+=(xterm_title_precmd);
+    preexec_functions+=(xterm_title_preexec);
+}
 
-    preexec_install
+function preexec_timing_install () {
+    preexec_install;
+    precmd_functions+=(timing_precmd);
+    preexec_functions+=(timing_preexec);
 }

--- a/undistract-me.sh
+++ b/undistract-me.sh
@@ -3,5 +3,9 @@
 # Check for interactive bash and that we haven't already been sourced.
 [ -z "$BASH_VERSION" -o -z "$PS1" -o -n "$last_command_started_cache" ] && return
 
+# Define parameters
+LONG_RUNNING_COMMAND_TIMEOUT=10
+UDM_PLAY_SOUND=1
+
 . /usr/share/undistract-me/long-running.bash
 notify_when_long_running_commands_finish_install


### PR DESCRIPTION
`undistract-me` is incompatible with any other script that relies on `bash_preexec`, for instance [bash-timer](https://github.com/hopeseekr/bash-timer).

That is because `undistract-me` uses variables `precmd` and `preexec` to pass its callback functions to `bash-preexec`. If any other script does the same thing, then whichever is sourced last overwrites these variables and the callbacks of the other scripts are discarded. 

To solve this problem, newer versions of `bash-preexec` provide arrays `precmd_functions` and `preexec_functions`, where several scripts can append their callback functions without overwriting / discarding those of other scripts. 

This pull requests addresses the issue described above by :   
1/ updating `preexec.bash` to the latest version found in https://glyf.livejournal.com/63106.html, that is https://www.twistedmatrix.com/users/glyph/preexec.bash.txt  
2/ using the callback arrays instead of variables

-----

I applied and tested these modifications on my machine. They work. Could you consider merging them ? Let me know if you want any additional information / help for testing / etc.

Cheers !