### PR TITLE
Run paplay on background to avoid delay

### DIFF
--- a/long-running.bash
+++ b/long-running.bash
@@ -99,7 +99,7 @@ function notify_when_long_running_commands_finish_install() {
                         "Command completed in $time_taken_human" \
                         "$__udm_last_command"
                         if [[ "$UDM_PLAY_SOUND" != 0 ]]; then
-                            paplay /usr/share/sounds/freedesktop/stereo/complete.oga
+                            paplay /usr/share/sounds/freedesktop/stereo/complete.oga &
                         fi
                     else
                         echo -ne "\a"


### PR DESCRIPTION
When UDM_PLAY_SOUND is enabled the paplay command waits until the sound is played hanging the terminal. Let's run the `paplay` in the background to return immediately.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>