### PR TITLE
Fix showing notifications in Wayland apps when running XWayland

### DIFF
--- a/long-running.bash
+++ b/long-running.bash
@@ -46,10 +46,13 @@ function notify_when_long_running_commands_finish_install() {
 
     function active_window_id () {
         if [[ -n $DISPLAY ]] ; then
-            xprop -root _NET_ACTIVE_WINDOW | awk '{print $5}'
-            return
+            active_window=$(xprop -root _NET_ACTIVE_WINDOW)
+            if [ $? -eq 0 ]; then
+                echo "$active_window" | awk '{print $5}'
+                return
+            fi
         fi
-        echo nowindowid
+        echo 0x0
     }
 
     function sec_to_human () {
@@ -78,7 +81,7 @@ function notify_when_long_running_commands_finish_install() {
             current_window=$(active_window_id)
             if [[ $current_window != $__udm_last_window ]] ||
                  [[ ! -z "$IGNORE_WINDOW_CHECK" ]] ||
-                [[ $current_window == "nowindowid" ]] ; then
+                [[ $current_window == "0x0" ]] ; then
                 local time_taken=$(( $now - $__udm_last_command_started ))
                 local time_taken_human=$(sec_to_human $time_taken)
                 local appname=$(basename "${__udm_last_command%% *}")


### PR DESCRIPTION
XWayland will return `0x0` (the root window id) when a Wayland window is focused, so if you switch to another Wayland window, the notification will not be displayed. To workaround this, I just replaced `nowindowid` with `0x0` as a marker for no window being focused.

_NOTE:_ This change doesn't implement window checking for Wayland, so notifications from a focused Wayland window will be displayed.

I also added an exit code check to only use the window id from xprop if it succeeds. This isn't essential to support Wayland + XWayland, but it should act as a safe guard if the X connection fails.